### PR TITLE
Add preview composables

### DIFF
--- a/app/src/main/java/com/ankit/appleui/ui/component/CtaSection.kt
+++ b/app/src/main/java/com/ankit/appleui/ui/component/CtaSection.kt
@@ -30,6 +30,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.foundation.pager.rememberPagerState
+import com.ankit.appleui.ui.theme.AppleUITheme
 import kotlinx.coroutines.launch
 
 @Composable
@@ -152,4 +155,13 @@ fun AppleTVStyleIndicator(
             )
         }
     }
-} 
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF000000)
+@Composable
+fun CtaSectionPreview() {
+    AppleUITheme {
+        val pagerState = rememberPagerState { 5 }
+        CtaSection(pagerState = pagerState)
+    }
+}

--- a/app/src/main/java/com/ankit/appleui/ui/component/HeroCollage.kt
+++ b/app/src/main/java/com/ankit/appleui/ui/component/HeroCollage.kt
@@ -40,6 +40,9 @@ import coil.compose.AsyncImage
 import coil.compose.AsyncImagePainter
 import coil.request.ImageRequest
 import com.ankit.appleui.ui.util.ImageResources
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.ui.tooling.preview.Preview
+import com.ankit.appleui.ui.theme.AppleUITheme
 
 // Sample data for hero posters
 data class PosterItem(val id: String, val imageUrl: String, val title: String)
@@ -181,4 +184,13 @@ fun HeroCollage(
                 .zIndex(2f) // Above the hero image but below indicators
         )
     }
-} 
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF000000)
+@Composable
+fun HeroCollagePreview() {
+    AppleUITheme {
+        val pagerState = rememberPagerState { heroPosters.size }
+        HeroCollage(pagerState = pagerState)
+    }
+}

--- a/app/src/main/java/com/ankit/appleui/ui/component/ShowCard.kt
+++ b/app/src/main/java/com/ankit/appleui/ui/component/ShowCard.kt
@@ -22,6 +22,9 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.compose.AsyncImagePainter
 import coil.request.ImageRequest
+import androidx.compose.ui.tooling.preview.Preview
+import com.ankit.appleui.ui.theme.AppleUITheme
+import com.ankit.appleui.ui.util.ImageResources
 
 data class ShowItem(
     val id: String,
@@ -83,4 +86,12 @@ fun ShowCard(
             }
         }
     }
-} 
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF000000)
+@Composable
+fun ShowCardPreview() {
+    AppleUITheme {
+        ShowCard(show = ImageResources.getShowItem(0))
+    }
+}

--- a/app/src/main/java/com/ankit/appleui/ui/navigation/BottomNavBar.kt
+++ b/app/src/main/java/com/ankit/appleui/ui/navigation/BottomNavBar.kt
@@ -34,6 +34,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.tooling.preview.Preview
+import com.ankit.appleui.ui.theme.AppleUITheme
 
 sealed class BottomNavItem(val title: String, val icon: ImageVector) {
     object AppleTVPlus : BottomNavItem("Apple TV+", Icons.Filled.Home)
@@ -82,4 +84,12 @@ fun BottomNavBar() {
             )
         }
     }
-} 
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF000000)
+@Composable
+fun BottomNavBarPreview() {
+    AppleUITheme {
+        BottomNavBar()
+    }
+}


### PR DESCRIPTION
## Summary
- add Preview imports and composables for ShowCard, CtaSection, HeroCollage and BottomNavBar
- wrap previews in `AppleUITheme` so they show properly

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6868f3cd43b08324bbe4e7c15e9a94aa