### PR TITLE
Add navigation and extra screens

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,9 +55,12 @@ dependencies {
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
-    
+
     // Material 3
     implementation(libs.androidx.material3)
+
+    // Navigation Compose
+    implementation(libs.androidx.navigation.compose)
     
     // Foundation (includes Pager - replaces Accompanist pager)
     implementation("androidx.compose.foundation:foundation")

--- a/app/src/main/java/com/ankit/appleui/MainActivity.kt
+++ b/app/src/main/java/com/ankit/appleui/MainActivity.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
-import com.ankit.appleui.ui.screen.HomeScreen
+import com.ankit.appleui.ui.navigation.AppNavHost
 import com.ankit.appleui.ui.theme.AppleUITheme
 
 class MainActivity : ComponentActivity() {
@@ -58,7 +58,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    HomeScreen()
+                    AppNavHost()
                 }
             }
         }

--- a/app/src/main/java/com/ankit/appleui/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/ankit/appleui/ui/navigation/AppNavHost.kt
@@ -1,0 +1,60 @@
+package com.ankit.appleui.ui.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import androidx.navigation.NavType
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.getValue
+import com.ankit.appleui.ui.screen.*
+
+sealed class Screen(val route: String) {
+    object Home : Screen("home")
+    object MLS : Screen("mls")
+    object Downloads : Screen("downloads")
+    object Search : Screen("search")
+    object Detail : Screen("detail/{showId}") {
+        fun createRoute(showId: String) = "detail/$showId"
+    }
+}
+
+@Composable
+fun AppNavHost(modifier: Modifier = Modifier) {
+    val navController = rememberNavController()
+    val backStackEntry by navController.currentBackStackEntryAsState()
+    Scaffold(
+        bottomBar = {
+            if (backStackEntry?.destination?.route != Screen.Detail.route) {
+                BottomNavBar(navController)
+            }
+        },
+        modifier = modifier
+    ) { innerPadding ->
+        NavHost(
+            navController = navController,
+            startDestination = Screen.Home.route,
+            modifier = Modifier.padding(innerPadding)
+        ) {
+            composable(Screen.Home.route) {
+                HomeScreen(onShowClick = { id ->
+                    navController.navigate(Screen.Detail.createRoute(id))
+                })
+            }
+            composable(Screen.MLS.route) { MlsScreen() }
+            composable(Screen.Downloads.route) { DownloadsScreen() }
+            composable(Screen.Search.route) { SearchScreen() }
+            composable(
+                route = Screen.Detail.route,
+                arguments = listOf(navArgument("showId") { type = NavType.StringType })
+            ) { entry ->
+                val showId = entry.arguments?.getString("showId") ?: return@composable
+                ShowDetailScreen(showId = showId, navController = navController)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ankit/appleui/ui/navigation/BottomNavBar.kt
+++ b/app/src/main/java/com/ankit/appleui/ui/navigation/BottomNavBar.kt
@@ -1,95 +1,76 @@
 package com.ankit.appleui.ui.navigation
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Star
-import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.compose.ui.tooling.preview.Preview
-import com.ankit.appleui.ui.theme.AppleUITheme
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
 
-sealed class BottomNavItem(val title: String, val icon: ImageVector) {
-    object AppleTVPlus : BottomNavItem("Apple TV+", Icons.Filled.Home)
-    object MLS : BottomNavItem("MLS", Icons.Filled.Star)
-    object Downloads : BottomNavItem("Downloads", Icons.Filled.PlayArrow)
-    object Search : BottomNavItem("Search", Icons.Filled.Search)
+sealed class BottomNavItem(val screen: Screen, val title: String, val icon: ImageVector) {
+    object AppleTVPlus : BottomNavItem(Screen.Home, "Apple TV+", Icons.Filled.Home)
+    object MLS : BottomNavItem(Screen.MLS, "MLS", Icons.Filled.Star)
+    object Downloads : BottomNavItem(Screen.Downloads, "Downloads", Icons.Filled.PlayArrow)
+    object Search : BottomNavItem(Screen.Search, "Search", Icons.Filled.Search)
 }
 
 @Composable
-fun BottomNavBar() {
+fun BottomNavBar(navController: NavHostController) {
     val items = listOf(
         BottomNavItem.AppleTVPlus,
         BottomNavItem.MLS,
         BottomNavItem.Downloads,
         BottomNavItem.Search
     )
-    
-    var selectedItem by remember { mutableIntStateOf(0) }
-    
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.destination?.route
+
     NavigationBar(
         containerColor = Color.Black,
-        contentColor = Color.White,
-        windowInsets = WindowInsets.navigationBars
+        contentColor = Color.White
     ) {
-        items.forEachIndexed { index, item ->
+        items.forEach { item ->
+            val selected = currentRoute == item.screen.route
             NavigationBarItem(
-                selected = selectedItem == index,
-                onClick = { selectedItem = index },
-                icon = { 
-                    Icon(
-                        imageVector = item.icon,
-                        contentDescription = item.title
-                    ) 
+                selected = selected,
+                onClick = {
+                    if (!selected) {
+                        navController.navigate(item.screen.route) {
+                            popUpTo(navController.graph.startDestinationId) {
+                                saveState = true
+                            }
+                            launchSingleTop = true
+                            restoreState = true
+                        }
+                    }
                 },
-                label = { 
-                    Text(text = item.title)
-                },
+                icon = { Icon(imageVector = item.icon, contentDescription = item.title) },
+                label = { Text(text = item.title) },
                 colors = NavigationBarItemDefaults.colors(
                     selectedIconColor = Color.White,
                     selectedTextColor = Color.White,
                     unselectedIconColor = Color(0xFF8A8A8A),
                     unselectedTextColor = Color(0xFF8A8A8A),
                     indicatorColor = Color.Black
-                ),
-                alwaysShowLabel = true
+                )
             )
         }
     }
 }
 
-@Preview(showBackground = true, backgroundColor = 0xFF000000)
 @Composable
 fun BottomNavBarPreview() {
-    AppleUITheme {
-        BottomNavBar()
-    }
+    val navController = rememberNavController()
+    BottomNavBar(navController)
 }

--- a/app/src/main/java/com/ankit/appleui/ui/screen/DownloadsScreen.kt
+++ b/app/src/main/java/com/ankit/appleui/ui/screen/DownloadsScreen.kt
@@ -1,0 +1,17 @@
+package com.ankit.appleui.ui.screen
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun DownloadsScreen() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text(text = "Downloads coming soon")
+    }
+}

--- a/app/src/main/java/com/ankit/appleui/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/ankit/appleui/ui/screen/HomeScreen.kt
@@ -64,13 +64,12 @@ import com.ankit.appleui.ui.component.CtaSection
 import com.ankit.appleui.ui.component.HeroCollage
 import com.ankit.appleui.ui.component.SectionHeader
 import com.ankit.appleui.ui.component.ShowCard
-import com.ankit.appleui.ui.navigation.BottomNavBar
 import com.ankit.appleui.ui.util.ImageResources
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun HomeScreen() {
+fun HomeScreen(onShowClick: (String) -> Unit) {
     val listState = rememberLazyListState()
     val pagerState = rememberPagerState { 5 }
     val coroutineScope = rememberCoroutineScope()
@@ -116,10 +115,6 @@ fun HomeScreen() {
         Scaffold(
             containerColor = Color.Black,
             contentColor = Color.White,
-            bottomBar = {
-                // Custom bottom navigation bar
-                BottomNavBar()
-            },
             topBar = {
                 // Only show the top app bar when scrolled down
                 AnimatedVisibility(
@@ -233,7 +228,8 @@ fun HomeScreen() {
                     ) {
                         items(shows) { show ->
                             ShowCard(
-                                show = show
+                                show = show,
+                                onClick = { onShowClick(show.id) }
                             )
                         }
                     }
@@ -254,7 +250,8 @@ fun HomeScreen() {
                     ) {
                         items(topShows) { show ->
                             ShowCard(
-                                show = show
+                                show = show,
+                                onClick = { onShowClick(show.id) }
                             )
                         }
                     }
@@ -275,7 +272,8 @@ fun HomeScreen() {
                     ) {
                         items(comingSoonShows) { show ->
                             ShowCard(
-                                show = show
+                                show = show,
+                                onClick = { onShowClick(show.id) }
                             )
                         }
                     }

--- a/app/src/main/java/com/ankit/appleui/ui/screen/MlsScreen.kt
+++ b/app/src/main/java/com/ankit/appleui/ui/screen/MlsScreen.kt
@@ -1,0 +1,15 @@
+package com.ankit.appleui.ui.screen
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun MlsScreen() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text(text = "MLS content goes here")
+    }
+}

--- a/app/src/main/java/com/ankit/appleui/ui/screen/SearchScreen.kt
+++ b/app/src/main/java/com/ankit/appleui/ui/screen/SearchScreen.kt
@@ -1,0 +1,15 @@
+package com.ankit.appleui.ui.screen
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun SearchScreen() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text(text = "Search screen placeholder")
+    }
+}

--- a/app/src/main/java/com/ankit/appleui/ui/screen/ShowDetailScreen.kt
+++ b/app/src/main/java/com/ankit/appleui/ui/screen/ShowDetailScreen.kt
@@ -1,0 +1,76 @@
+package com.ankit.appleui.ui.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.graphics.Color
+import com.ankit.appleui.ui.util.ImageResources
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ShowDetailScreen(
+    showId: String,
+    navController: NavController
+) {
+    val show = ImageResources.getShowItem(showId.toInt())
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        CenterAlignedTopAppBar(
+            title = { Text(text = show.title) },
+            navigationIcon = {
+                IconButton(onClick = { navController.popBackStack() }) {
+                    Icon(
+                        imageVector = Icons.Default.ArrowBack,
+                        contentDescription = "Back",
+                        tint = Color.White
+                    )
+                }
+            },
+            colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                containerColor = Color.Black,
+                titleContentColor = Color.White
+            )
+        )
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            AsyncImage(
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(show.imageUrl)
+                    .crossfade(true)
+                    .build(),
+                contentDescription = show.title,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize(0.5f)
+            )
+            Text(
+                text = "Enjoy \"${show.title}\" only on Apple TV+.",
+                style = MaterialTheme.typography.bodyLarge,
+                color = Color.White
+            )
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.9.0"
 activityCompose = "1.10.1"
 composeBom = "2024.09.00"
+navigationCompose = "2.7.7"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -24,6 +25,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- introduce `AppNavHost` with navigation graph
- attach `AppNavHost` in `MainActivity`
- update `BottomNavBar` to work with nav controller
- refactor `HomeScreen` to pass show click events
- add placeholder screens and show detail screen
- include `navigation-compose` dependency

## Testing
- `./gradlew build --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6868f7dd0c748324997118be5fe02997