### PR TITLE
Remove TopAppBar components

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@
 2. **Hero Section**: Beautiful hero carousel with animated transitions and Apple TV+ style dot indicators
 3. **Call-to-Action Section**: Clean, minimal CTA section with subscription details and trial button
 4. **Content Carousels**: Horizontal scrolling content sections for Movies, TV Shows and other categories
-5. **Animated TopAppBar**: The top app bar appears and disappears based on scroll position
 
 ## Screenshots 📸
 

--- a/app/src/main/java/com/ankit/appleui/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/ankit/appleui/ui/screen/HomeScreen.kt
@@ -16,21 +16,14 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -93,41 +86,7 @@ fun HomeScreen(onShowClick: (String) -> Unit) {
         // Main content scaffold
         Scaffold(
             containerColor = Color.Black,
-            contentColor = Color.White,
-            topBar = {
-                val topBarColor by animateColorAsState(
-                    targetValue = if (showTopBarContent) Color.Black else Color.Transparent,
-                    label = "topBarColor"
-                )
-
-                CenterAlignedTopAppBar(
-                    colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                        containerColor = topBarColor,
-                        titleContentColor = Color.White
-                    ),
-                    title = {
-                        AnimatedVisibility(showTopBarContent) {
-                            Text(
-                                text = "Apple TV+",
-                                fontSize = 18.sp,
-                                fontWeight = FontWeight.SemiBold
-                            )
-                        }
-                    },
-                    actions = {
-                        AnimatedVisibility(showTopBarContent) {
-                            IconButton(onClick = { /* Sign in action */ }) {
-                                Icon(
-                                    Icons.Default.Person,
-                                    contentDescription = "Sign In",
-                                    tint = Color.White
-                                )
-                            }
-                        }
-                    },
-                    modifier = Modifier.statusBarsPadding()
-                )
-            }
+            contentColor = Color.White
         ) { innerPadding ->
             // Main scrollable content
             LazyColumn(

--- a/app/src/main/java/com/ankit/appleui/ui/screen/ShowDetailScreen.kt
+++ b/app/src/main/java/com/ankit/appleui/ui/screen/ShowDetailScreen.kt
@@ -1,16 +1,14 @@
 package com.ankit.appleui.ui.screen
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -25,7 +23,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
 import com.ankit.appleui.ui.util.ImageResources
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ShowDetailScreen(
     showId: String,
@@ -33,23 +30,20 @@ fun ShowDetailScreen(
 ) {
     val show = ImageResources.getShowItem(showId.toInt())
 
-    Column(modifier = Modifier.fillMaxSize()) {
-        CenterAlignedTopAppBar(
-            title = { Text(text = show.title) },
-            navigationIcon = {
-                IconButton(onClick = { navController.popBackStack() }) {
-                    Icon(
-                        imageVector = Icons.Default.ArrowBack,
-                        contentDescription = "Back",
-                        tint = Color.White
-                    )
-                }
-            },
-            colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                containerColor = Color.Black,
-                titleContentColor = Color.White
+    Box(modifier = Modifier.fillMaxSize()) {
+        IconButton(
+            onClick = { navController.popBackStack() },
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(16.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.ArrowBack,
+                contentDescription = "Back",
+                tint = Color.White
             )
-        )
+        }
+
         Column(
             modifier = Modifier
                 .fillMaxSize()

--- a/steps
+++ b/steps
@@ -23,19 +23,15 @@ Below is a **component-by-component recipe** for building the Apple TV+ landing 
    WindowCompat.setDecorFitsSystemWindows(window, false)
    ```
 
-2. **Scaffold with TopAppBar and BottomNav**:
+2. **Scaffold with BottomNav**:
    ```kotlin
-   val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
-   
    Scaffold(
-       topBar = {
-           CenterAlignedTopAppBar(
-               title = { /* Logo */ },
-               scrollBehavior = scrollBehavior
-           )
-       },
        bottomBar = { BottomNavBar() }
-   ) { innerPadding → LazyColumn(contentPadding = innerPadding) { /* content */ } }
+   ) { innerPadding →
+       LazyColumn(contentPadding = innerPadding) {
+           /* content */
+       }
+   }
    ```
 
 ---


### PR DESCRIPTION
## Summary
- drop the animated TopAppBar from HomeScreen
- replace TopAppBar in ShowDetailScreen with a simple back button overlay
- update documentation to remove references to the TopAppBar

## Testing
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_686c43b01c4c8324a90c2b6309b64821