### PR TITLE
Add enhancements to search, downloads and MLS screens

### DIFF
--- a/app/src/main/java/com/ankit/appleui/ui/screen/DownloadsScreen.kt
+++ b/app/src/main/java/com/ankit/appleui/ui/screen/DownloadsScreen.kt
@@ -1,17 +1,37 @@
 package com.ankit.appleui.ui.screen
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
 @Composable
 fun DownloadsScreen() {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text(text = "Downloads coming soon")
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(
+                imageVector = Icons.Default.PlayArrow,
+                contentDescription = null,
+                tint = Color.Gray,
+                modifier = Modifier.size(64.dp)
+            )
+            Spacer(modifier = Modifier.size(8.dp))
+            Text(text = "No downloads yet", color = Color.White)
+            Spacer(modifier = Modifier.size(4.dp))
+            Text(
+                text = "Movies and shows you download will appear here.",
+                color = Color.Gray
+            )
+        }
     }
 }

--- a/app/src/main/java/com/ankit/appleui/ui/screen/MlsScreen.kt
+++ b/app/src/main/java/com/ankit/appleui/ui/screen/MlsScreen.kt
@@ -1,15 +1,65 @@
 package com.ankit.appleui.ui.screen
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.ankit.appleui.ui.component.SectionHeader
+import com.ankit.appleui.ui.component.ShowCard
+import com.ankit.appleui.ui.util.ImageResources
 
 @Composable
 fun MlsScreen() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text(text = "MLS content goes here")
+    val highlights = List(10) { index ->
+        ImageResources.getShowItem(index)
+    }
+
+    val topPlays = List(6) { index ->
+        ImageResources.getShowItem(index + 10)
+    }
+
+    LazyColumn {
+        item {
+            SectionHeader(title = "MLS Highlights", showChevron = false)
+        }
+
+        item {
+            LazyRow(
+                contentPadding = PaddingValues(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                items(highlights) { show ->
+                    ShowCard(show = show)
+                }
+            }
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+
+        item {
+            SectionHeader(title = "Top Plays", showChevron = false)
+        }
+
+        item {
+            LazyRow(
+                contentPadding = PaddingValues(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                items(topPlays) { show ->
+                    ShowCard(show = show)
+                }
+            }
+        }
+
+        item { Spacer(modifier = Modifier.height(64.dp)) }
     }
 }

--- a/app/src/main/java/com/ankit/appleui/ui/screen/SearchScreen.kt
+++ b/app/src/main/java/com/ankit/appleui/ui/screen/SearchScreen.kt
@@ -1,15 +1,100 @@
 package com.ankit.appleui.ui.screen
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.ankit.appleui.ui.component.ShowCard
+import com.ankit.appleui.ui.component.ShowItem
+import com.ankit.appleui.ui.util.ImageResources
 
 @Composable
 fun SearchScreen() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text(text = "Search screen placeholder")
+    data class SearchItem(val show: ShowItem, val category: String)
+
+    var query by remember { mutableStateOf("") }
+    var selectedCategory by remember { mutableStateOf("All") }
+
+    val categories = listOf("All", "Movies", "Series", "Sports")
+
+    val items = remember {
+        List(20) { index ->
+            val category = when (index % 3) {
+                0 -> "Movies"
+                1 -> "Series"
+                else -> "Sports"
+            }
+            SearchItem(ImageResources.getShowItem(index), category)
+        }
+    }
+
+    val filtered = items.filter { item ->
+        (selectedCategory == "All" || item.category == selectedCategory) &&
+            item.show.title.contains(query, ignoreCase = true)
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        TextField(
+            value = query,
+            onValueChange = { query = it },
+            placeholder = { Text(text = "Search") },
+            singleLine = true,
+            colors = TextFieldDefaults.colors(
+                focusedContainerColor = Color(0xFF1C1C1E),
+                unfocusedContainerColor = Color(0xFF1C1C1E),
+                focusedTextColor = Color.White,
+                unfocusedTextColor = Color.White,
+                focusedPlaceholderColor = Color(0xFFAAAAAA),
+                unfocusedPlaceholderColor = Color(0xFFAAAAAA),
+                cursorColor = Color.White
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        )
+
+        TabRow(
+            selectedTabIndex = categories.indexOf(selectedCategory),
+            containerColor = Color.Black,
+            contentColor = Color.White
+        ) {
+            categories.forEachIndexed { index, title ->
+                Tab(
+                    selected = selectedCategory == title,
+                    onClick = { selectedCategory = title },
+                    text = { Text(text = title) }
+                )
+            }
+        }
+
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(2),
+            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier.fillMaxSize()
+        ) {
+            items(filtered) { item ->
+                ShowCard(show = item.show)
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- expand Search screen with category tabs and filtering
- show additional sections on MLS screen
- improve Downloads placeholder with icon and details

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_686c811975888324ae1f8c30f578610f